### PR TITLE
Fix loading for games with underscore in the filename

### DIFF
--- a/play.sh
+++ b/play.sh
@@ -2,7 +2,7 @@
 
 snapshot=$1
 full=${1##*/}
-game=${full%%_*}
+game=${full%_*}
 rom="roms/$game.bin"
 shift
 

--- a/record.sh
+++ b/record.sh
@@ -2,7 +2,7 @@
 
 snapshot=$1
 full=${1##*/}
-game=${full%%_*}
+game=${full%_*}
 file=${full%.*}
 rom="roms/$game.bin"
 shift


### PR DESCRIPTION
Small fix, to allow testing of games with an underscore in the ROM filename, e.g., _space_invaders_.
