### PR TITLE
Make play_random to fill memory

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -86,7 +86,8 @@ class Agent:
     # play given number of steps
     for i in xrange(random_steps):
       # use exploration rate 1 = completely random
-      self.step(1)
+      action, reward, screen, terminal = self.step(1)
+      self.mem.add(action, reward, screen, terminal)
 
   def train(self, train_steps, epoch = 0):
     # do not do restart here, continue from testing


### PR DESCRIPTION
`play_random` function, which is called before training to populate replay memory was not actually adding replay to `ReplayMemory`. This PR fixes it.

`play_random` function is not used anywhere else, so this change should not have any side effect.
https://github.com/tambetm/simple_dqn/search?utf8=✓&q=play_random
