### PR TITLE
Change network sync timing from #trainings to #steps

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -22,6 +22,7 @@ class Agent:
 
     self.train_frequency = args.train_frequency
     self.train_repeat = args.train_repeat
+    self.target_steps = args.target_steps
 
     self.callback = None
 
@@ -97,6 +98,9 @@ class Agent:
       # perform game step
       action, reward, screen, terminal = self.step(self._explorationRate())
       self.mem.add(action, reward, screen, terminal)
+      # Update target network every target_steps steps
+      if self.target_steps and i % self.target_steps == 0:
+        self.net.update_target_network()
       # train after every train_frequency steps
       if self.mem.count > self.mem.batch_size and i % self.train_frequency == 0:
         # train for train_repeat times

--- a/src/deepqnetwork.py
+++ b/src/deepqnetwork.py
@@ -61,6 +61,7 @@ class DeepQNetwork:
       assert false, "Unknown optimizer"
 
     # create target model
+    self.train_iterations = 0
     if args.target_steps:
       self.target_model = Model(layers = self._createLayers(num_actions))
       # Bug fix
@@ -162,6 +163,9 @@ class DeepQNetwork:
 
     # perform optimization
     self.optimizer.optimize(self.model.layers_to_optimize, epoch)
+
+    # increase number of weight updates (needed for stats callback)
+    self.train_iterations += 1
 
     # calculate statistics
     if self.callback:

--- a/src/deepqnetwork.py
+++ b/src/deepqnetwork.py
@@ -61,9 +61,7 @@ class DeepQNetwork:
       assert false, "Unknown optimizer"
 
     # create target model
-    self.target_steps = args.target_steps
-    self.train_iterations = 0
-    if self.target_steps:
+    if args.target_steps:
       self.target_model = Model(layers = self._createLayers(num_actions))
       # Bug fix
       for l in self.target_model.layers.layers:
@@ -116,9 +114,6 @@ class DeepQNetwork:
     assert prestates.shape == poststates.shape
     assert prestates.shape[0] == actions.shape[0] == rewards.shape[0] == poststates.shape[0] == terminals.shape[0]
 
-    if self.target_steps and self.train_iterations % self.target_steps == 0:
-      self.update_target_network()
-
     # feed-forward pass for poststates to get Q-values
     self._setInput(poststates)
     postq = self.target_model.fprop(self.input, inference = True)
@@ -167,9 +162,6 @@ class DeepQNetwork:
 
     # perform optimization
     self.optimizer.optimize(self.model.layers_to_optimize, epoch)
-
-    # increase number of weight updates (needed for target clone interval)
-    self.train_iterations += 1
 
     # calculate statistics
     if self.callback:

--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,6 @@ netarg.add_argument("--batch_size", type=int, default=32, help="Batch size for n
 netarg.add_argument('--optimizer', choices=['rmsprop', 'adam', 'adadelta'], default='rmsprop', help='Network optimization algorithm.')
 netarg.add_argument("--decay_rate", type=float, default=0.95, help="Decay rate for RMSProp and Adadelta algorithms.")
 netarg.add_argument("--clip_error", type=float, default=1, help="Clip error term in update between this number and its negative.")
-netarg.add_argument("--target_steps", type=int, default=10000, help="Copy main network to target network after this many steps.")
 netarg.add_argument("--min_reward", type=float, default=-1, help="Minimum reward.")
 netarg.add_argument("--max_reward", type=float, default=1, help="Maximum reward.")
 netarg.add_argument("--batch_norm", type=str2bool, default=False, help="Use batch normalization in all layers.")
@@ -61,6 +60,7 @@ antarg.add_argument("--exploration_decay_steps", type=float, default=1000000, he
 antarg.add_argument("--exploration_rate_test", type=float, default=0.05, help="Exploration rate used during testing.")
 antarg.add_argument("--train_frequency", type=int, default=4, help="Perform training after this many game steps.")
 antarg.add_argument("--train_repeat", type=int, default=1, help="Number of times to sample minibatch during training.")
+antarg.add_argument("--target_steps", type=int, default=10000, help="Copy main network to target network after this many game steps.")
 antarg.add_argument("--random_starts", type=int, default=30, help="Perform max this number of dummy actions after game restart, to produce more random game dynamics.")
 
 nvisarg = parser.add_argument_group('Visualization')


### PR DESCRIPTION
Another PR following #32 .

This PR changes the timing measure for agent to sync target network from #trainings to #steps.
For example, before applying this change, networks are synced every 10000 network training (parameter update), but after applying this change, networks are synced every 10000 environmental steps. That is `10000 / T` every network trainings and every about `10000 * F` frames, where `T` and `F` correspond to command line arguments, `train_frequency` and `frame_skip` respectively.

The result on breakout can be found [here](https://gist.github.com/mthrok/762736beef23d865816ab78b2172bbd1).

The learning speed gets even faster, but it does not necessarily yield a good result on breakout. Tweaking terminal condition to take life loss into consideration might give better result.

<img width="549" alt="screen shot 2016-09-09 at 6 15 55 pm" src="https://cloud.githubusercontent.com/assets/855818/18406942/78a74a64-76b9-11e6-8076-2457ef6deb22.png">
