### PR TITLE
Treat life loss as termination in training mode

### DIFF
--- a/src/environment.py
+++ b/src/environment.py
@@ -83,7 +83,16 @@ class ALEEnvironment(Environment):
     return len(self.actions)
 
   def restart(self):
-    self.ale.reset_game()
+    # In test mode, the game is simply initialized. In train mode, if the game
+    # is in terminal state due to a life loss but not yet game over, then only
+    # life loss flag is reset so that the next game starts from the current
+    # state. Otherwise, the game is simply initialized.
+    if (
+        self.mode == 'test' or
+        not self.life_lost or  # `reset` called in a middle of episode
+        self.ale.game_over()  # all lives are lost
+    ):
+      self.ale.reset_game()
     self.life_lost = False
 
   def act(self, action):

--- a/src/environment.py
+++ b/src/environment.py
@@ -28,6 +28,10 @@ class Environment:
     # Returns if game is done
     raise NotImplementedError
 
+  def setMode(self, mode):
+    # Set training/test mode. Not used in Gym environment
+    self.mode = mode
+
 class ALEEnvironment(Environment):
   def __init__(self, rom_file, args):
     from ale_python_interface import ALEInterface
@@ -73,14 +77,19 @@ class ALEEnvironment(Environment):
     self.screen_width = args.screen_width
     self.screen_height = args.screen_height
 
+    self.life_lost = False
+
   def numActions(self):
     return len(self.actions)
 
   def restart(self):
     self.ale.reset_game()
+    self.life_lost = False
 
   def act(self, action):
+    lives = self.ale.lives()
     reward = self.ale.act(self.actions[action])
+    self.life_lost = (not lives == self.ale.lives())
     return reward
 
   def getScreen(self):
@@ -89,6 +98,8 @@ class ALEEnvironment(Environment):
     return resized
 
   def isTerminal(self):
+    if self.mode == 'train':
+      return self.ale.game_over() or self.life_lost
     return self.ale.game_over()
 
 class GymEnvironment(Environment):

--- a/src/main.py
+++ b/src/main.py
@@ -111,6 +111,8 @@ if args.load_weights:
 
 if args.play_games:
   logger.info("Playing for %d game(s)" % args.play_games)
+  # Set env mode test so that loss of life is not considered as terminal
+  env.setMode('test')
   stats.reset()
   agent.play(args.play_games)
   stats.write(0, "play")
@@ -128,6 +130,8 @@ if args.play_games:
 if args.random_steps:
   # populate replay memory with random steps
   logger.info("Populating replay memory with %d random moves" % args.random_steps)
+  # Set env mode test so that loss of life is considered as terminal
+  env.setMode('train')
   stats.reset()
   agent.play_random(args.random_steps)
   stats.write(0, "random")
@@ -138,6 +142,8 @@ for epoch in xrange(args.start_epoch, args.epochs):
 
   if args.train_steps:
     logger.info(" Training for %d steps" % args.train_steps)
+    # Set env mode test so that loss of life is considered as terminal
+    env.setMode('train')
     stats.reset()
     agent.train(args.train_steps, epoch)
     stats.write(epoch + 1, "train")
@@ -149,6 +155,8 @@ for epoch in xrange(args.start_epoch, args.epochs):
 
   if args.test_steps:
     logger.info(" Testing for %d steps" % args.test_steps)
+    # Set env mode test so that loss of life is not considered as terminal
+    env.setMode('test')
     stats.reset()
     agent.test(args.test_steps, epoch)
     stats.write(epoch + 1, "test")


### PR DESCRIPTION
Another PR following #32.

This PR make the treatment of live count different in test mode and train mode by introducing `mode` attribute and `life_lost` flag in environment.

On breakout, this change yields faster learning and better result. 

<img width="547" alt="screen shot 2016-09-24 at 10 45 15 am" src="https://cloud.githubusercontent.com/assets/855818/18810172/3cf98e64-8244-11e6-9e59-50a9e4140f50.png">

https://gist.github.com/mthrok/93bcaf2ef996de6ad156ee3b994d5dd4
